### PR TITLE
Slice 1: Model switch to Opus + notes field

### DIFF
--- a/src/app/api/outreach/generate-message/route.ts
+++ b/src/app/api/outreach/generate-message/route.ts
@@ -69,6 +69,10 @@ function buildClaudePrompt(
     Drew: "Drew is the co-founder/COO, leading with strategic business outcomes and ROI.",
   };
 
+  const notesSection = contact.notes
+    ? `\nNotes about this contact: ${contact.notes}`
+    : "";
+
   return `Write a LinkedIn outreach message from ${assignee} to ${contact.name}.
 
 Contact details:
@@ -76,7 +80,7 @@ Contact details:
 - Title: ${contact.title}
 - Company: ${contact.company}
 - Sector: ${contact.sector.join(", ") || "manufacturing"}
-- ICP fit: ${contact.fitTier}
+- ICP fit: ${contact.fitTier}${notesSection}
 
 Sender: ${assignee}
 ${senderContext[assignee]}
@@ -120,8 +124,8 @@ export async function POST(request: NextRequest) {
       const client = new Anthropic({ apiKey });
 
       const response = await client.messages.create({
-        model: "claude-haiku-4-5",
-        max_tokens: 300,
+        model: "claude-opus-4-5",
+        max_tokens: 180,
         system: ELOSO_CONTEXT,
         messages: [
           {


### PR DESCRIPTION
## Summary
- Switch model from `claude-haiku-4-5` to `claude-opus-4-5`
- Reduce `max_tokens` from 300 to 180
- Pass `contact.notes` into the Claude prompt when present

## Test plan
- [ ] Generate a message for a contact with notes → notes should influence the output
- [ ] TypeScript builds cleanly ✅

Linear: BIS-589