### PR TITLE
Slice 4: Problem-hypothesis framing with sector-specific examples

### DIFF
--- a/src/app/api/outreach/generate-message/route.ts
+++ b/src/app/api/outreach/generate-message/route.ts
@@ -31,7 +31,13 @@ Rules:
 1. Under 280 characters total.
 2. Casual, conversational — contractions, short sentences, no corporate speak. Never: "I'd be pleased to", "leverage", "synergy", "circle back".
 3. Open with a sector-aware hook specific to the contact's industry pain.
-4. Include a problem-hypothesis: "I think you might have [specific problem]. Is that true?" — must be role+sector specific.
+4. Include a problem-hypothesis in the form "I think you might have [specific problem]. Is that true?" — must be role+sector specific, never generic. Examples by sector:
+   - Defense/A&D: "I think you might have demand plans that break down the moment a program gets delayed. Is that true?"
+   - eVTOL/advanced air: "I think you might be struggling with component lead times that don't match your production ramp schedule. Is that true?"
+   - Rail: "I think your backlog-to-revenue gap is creating forecasting blind spots for finance. Is that true?"
+   - Robotics/machine-vision: "I think your hardware BOM demand planning still lives in spreadsheets that can't keep up with software release cycles. Is that true?"
+   - Heavy equipment/capital goods: "I think your CSCO team is measured on cost metrics that miss the revenue impact of late deliveries. Is that true?"
+   BAD (too generic): "I think you might have supply chain challenges. Is that true?"
 5. End with a soft CTA: "worth 20 min?" or "relevant to you?" style.
 6. Sender angles — Ben: vision/product ("why now"); Jake: technical/implementation ("how it works"); Drew: strategic/market ("business outcomes").
 7. Skip COO titles entirely — do not write a message for a COO.`;

--- a/src/lib/outreach.ts
+++ b/src/lib/outreach.ts
@@ -245,16 +245,20 @@ export function generateMessage(task: OutreachTask): GeneratedMessage {
     roleOpener = `I've been looking at what ${companyShort} is doing and think there's a real connection to what we're working on.`;
   }
 
-  // Sector-aware hook
+  // Sector-aware hook with specific pain point and problem hypothesis
   let sectorHook = "";
   if (contact.sector.some((s) => s.includes("defense"))) {
-    sectorHook = " Defense-sector supply chains face unique challenges around backlog depth and component lead times — exactly the problem we're built for.";
-  } else if (contact.sector.includes("evtol") || contact.sector.includes("ev-battery")) {
-    sectorHook = " The supply chain complexity for next-gen mobility is intense — long component lead times, strict quality requirements, and huge backlog pressure.";
+    sectorHook = " Defense supply chains break when programs slip — demand plans that assumed a delivery date are suddenly wrong by months, and the backlog depth hides it until it's too late.";
+  } else if (contact.sector.includes("evtol")) {
+    sectorHook = " eVTOL production ramps are brutal — component lead times built for aerospace volumes don't match the pace your program needs, and that gap shows up in the backlog before it shows up in the P&L.";
+  } else if (contact.sector.includes("ev-battery")) {
+    sectorHook = " EV supply chains have a unique problem: battery cell lead times are long, specs change fast, and demand plans are obsolete before they're published.";
   } else if (contact.sector.includes("rail-transportation-equipment")) {
-    sectorHook = " Rail equipment manufacturing is a great example of where backlog-to-revenue gap creates real pain at scale.";
-  } else if (contact.sector.includes("robotics") || contact.sector.includes("machine-vision") || contact.sector.includes("enterprise-tech")) {
-    sectorHook = " Enterprise tech supply chains — especially at the hardware-software interface — are where demand planning inaccuracies hit hardest.";
+    sectorHook = " Rail equipment backlogs are long and the revenue recognition gap is real — components arriving months before the car ships means cash tied up with no revenue signal.";
+  } else if (contact.sector.includes("robotics") || contact.sector.includes("machine-vision")) {
+    sectorHook = " Robotics hardware BOMs are a demand planning nightmare — hardware lead times are 16-20 weeks, software releases ship on 2-week cycles, and the mismatch creates constant expediting costs.";
+  } else if (contact.sector.includes("enterprise-tech")) {
+    sectorHook = " Hardware-software supply chains are where demand planning inaccuracies hit hardest — one silicon shortage can stall an entire software release cycle.";
   }
 
   const message = [


### PR DESCRIPTION
## Summary
- Expand system prompt rule 4 with sector-specific problem hypothesis examples for defense, eVTOL, ev-battery, rail, robotics, machine-vision, and heavy equipment
- Add good/bad example contrast to prevent generic hypotheses
- Update `outreach.ts` sector hooks with specific operational pain points per sector (replaces generic "supply chain is hard" hooks)

## Test plan
- [ ] Generate messages for defense, eVTOL, rail, robotics contacts → each should have a distinct, specific problem hypothesis
- [ ] Template fallback also uses updated sector hooks
- [ ] TypeScript builds cleanly ✅

Linear: BIS-592