### PR TITLE
feat: prospect feedback loop

### DIFF
--- a/src/app/api/outreach/feedback/route.ts
+++ b/src/app/api/outreach/feedback/route.ts
@@ -1,0 +1,167 @@
+/**
+ * POST /api/outreach/feedback
+ *
+ * Records thumbs up/down feedback on a prospect contact.
+ * Feedback is stored as meta fields on the Kissinger person entity:
+ *   - feedback_thumb: "up" | "down"
+ *   - feedback_text: string (optional)
+ *   - feedback_date: ISO timestamp
+ *
+ * Request body (JSON):
+ * {
+ *   entityId: string,
+ *   thumb: "up" | "down",
+ *   text?: string
+ * }
+ *
+ * Response:
+ * { ok: true }
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+
+const KISSINGER_API_URL =
+  process.env.KISSINGER_API_URL ?? "http://localhost:8080/graphql";
+const KISSINGER_API_TOKEN = process.env.KISSINGER_API_TOKEN ?? "";
+
+const COOKIE_NAME = "eloso_session";
+const SESSION_VALUE = "authenticated";
+
+/** Minimal GraphQL mutation helper (no Next.js caching — mutations bypass cache). */
+async function gqlMutate<T = unknown>(
+  query: string,
+  variables: Record<string, unknown>
+): Promise<T> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (KISSINGER_API_TOKEN) {
+    headers["Authorization"] = `Bearer ${KISSINGER_API_TOKEN}`;
+  }
+
+  const res = await fetch(KISSINGER_API_URL, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ query, variables }),
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    throw new Error(`Kissinger request failed: ${res.status} ${res.statusText}`);
+  }
+
+  const json = (await res.json()) as { data?: T; errors?: unknown[] };
+  if (json.errors && json.errors.length > 0) {
+    throw new Error(`Kissinger errors: ${JSON.stringify(json.errors)}`);
+  }
+  return json.data as T;
+}
+
+const ENTITY_META_QUERY = `
+  query EntityMeta($id: String!) {
+    entity(id: $id) {
+      meta { key value }
+    }
+  }
+`;
+
+const UPDATE_ENTITY_MUTATION = `
+  mutation UpdateEntityMeta($id: String!, $input: UpdateEntityInput!) {
+    updateEntity(id: $id, input: $input) {
+      id
+      meta { key value }
+    }
+  }
+`;
+
+export async function POST(request: NextRequest) {
+  // Auth: valid session cookie OR internal secret
+  const internalSecret = process.env.LOBSTER_INTERNAL_SECRET;
+  const providedSecret = request.headers.get("X-Internal-Secret");
+  const isInternalCall =
+    internalSecret && providedSecret && providedSecret === internalSecret;
+
+  const cookieHeader = request.headers.get("cookie") ?? "";
+  const hasSessionCookie = cookieHeader
+    .split(";")
+    .map((c) => c.trim())
+    .some((c) => c === `${COOKIE_NAME}=${SESSION_VALUE}`);
+
+  if (!isInternalCall && !hasSessionCookie) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { entityId, thumb, text } = body as {
+    entityId?: string;
+    thumb?: string;
+    text?: string;
+  };
+
+  if (!entityId || typeof entityId !== "string") {
+    return NextResponse.json(
+      { error: "entityId is required" },
+      { status: 400 }
+    );
+  }
+
+  if (thumb !== "up" && thumb !== "down") {
+    return NextResponse.json(
+      { error: "thumb must be 'up' or 'down'" },
+      { status: 400 }
+    );
+  }
+
+  if (text !== undefined && typeof text !== "string") {
+    return NextResponse.json(
+      { error: "text must be a string if provided" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    // Fetch current meta to merge (updateEntity replaces meta entirely)
+    const entityData = await gqlMutate<{
+      entity: { meta: { key: string; value: string }[] };
+    }>(ENTITY_META_QUERY, { id: entityId });
+
+    const existingMeta = entityData.entity?.meta ?? [];
+
+    // Remove any existing feedback fields before re-adding
+    const filteredMeta = existingMeta.filter(
+      (m) =>
+        m.key !== "feedback_thumb" &&
+        m.key !== "feedback_text" &&
+        m.key !== "feedback_date"
+    );
+
+    const now = new Date().toISOString();
+
+    const newMeta = [
+      ...filteredMeta,
+      { key: "feedback_thumb", value: thumb },
+      { key: "feedback_date", value: now },
+      ...(text ? [{ key: "feedback_text", value: text }] : []),
+    ];
+
+    await gqlMutate(UPDATE_ENTITY_MUTATION, {
+      id: entityId,
+      input: { meta: newMeta },
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error("[outreach/feedback] Failed to record feedback:", msg);
+    return NextResponse.json(
+      { error: "Failed to record feedback" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/outreach/reload-tasks/route.ts
+++ b/src/app/api/outreach/reload-tasks/route.ts
@@ -24,6 +24,8 @@
 
 import { NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
+import { readFile } from "fs/promises";
+import path from "path";
 import { fetchAllEntities, isUSContact } from "@/lib/kissinger";
 
 const KISSINGER_API_URL =
@@ -32,6 +34,39 @@ const KISSINGER_API_TOKEN = process.env.KISSINGER_API_TOKEN ?? "";
 
 /** Target number of outreach tasks after reload. */
 const FILL_TARGET = 100;
+
+/** Prospect criteria file path (written by daily refinement job). */
+const CRITERIA_FILE = path.join(
+  process.env.HOME ?? "/home/lobster",
+  "lobster-workspace/data/prospect-criteria.json"
+);
+
+/** Prospect criteria from the daily refinement job. */
+interface ProspectCriteria {
+  preferred_titles?: string[];
+  excluded_titles?: string[];
+  preferred_sectors?: string[];
+  excluded_sectors?: string[];
+  preferred_company_size?: string;
+  notes?: string;
+}
+
+/** Load prospect criteria from disk. Returns null if file doesn't exist or is malformed. */
+async function loadProspectCriteria(): Promise<ProspectCriteria | null> {
+  try {
+    const raw = await readFile(CRITERIA_FILE, "utf-8");
+    return JSON.parse(raw) as ProspectCriteria;
+  } catch {
+    // File doesn't exist yet or is malformed — ignore
+    return null;
+  }
+}
+
+/** Check if a title matches any of the given keywords (case-insensitive substring). */
+function titleMatches(title: string, keywords: string[]): boolean {
+  const lower = title.toLowerCase();
+  return keywords.some((kw) => lower.includes(kw.toLowerCase()));
+}
 
 /** Minimal gql helper (no cache — mutations must bypass Next.js cache). */
 async function gqlMutate<T = unknown>(
@@ -111,6 +146,9 @@ export async function POST(request: Request) {
   }
 
   try {
+    // Load prospect criteria (written by daily refinement job, optional)
+    const criteria = await loadProspectCriteria();
+
     // Fetch all person entities (includes location field for US detection).
     // This is cached at TTL=120s in fetchAllEntities — fine for reads.
     // We pass cache: no-store on mutations only.
@@ -129,9 +167,58 @@ export async function POST(request: Request) {
     );
 
     // Determine eligible candidates to add (linkedin + US, not already prospect-contact)
-    const candidates = nonOutreach.filter(
+    let candidates = nonOutreach.filter(
       (p) => p.tags.includes("linkedin") && isUSContact(p)
     );
+
+    // Apply prospect criteria filtering/prioritization if available
+    if (criteria) {
+      const excludedTitles = criteria.excluded_titles ?? [];
+      const preferredTitles = criteria.preferred_titles ?? [];
+      const excludedSectors = criteria.excluded_sectors ?? [];
+      const preferredSectors = criteria.preferred_sectors ?? [];
+
+      // Filter: skip excluded titles
+      if (excludedTitles.length > 0) {
+        candidates = candidates.filter((p) => {
+          const title = p.meta?.find((m) => m.key === "title")?.value ?? "";
+          return !titleMatches(title, excludedTitles);
+        });
+      }
+
+      // Filter: skip excluded sectors (via person tags)
+      if (excludedSectors.length > 0) {
+        candidates = candidates.filter((p) => {
+          const personTags = p.tags.map((t) => t.toLowerCase());
+          return !excludedSectors.some((s) =>
+            personTags.includes(s.toLowerCase())
+          );
+        });
+      }
+
+      // Prioritize: preferred titles and sectors go first
+      if (preferredTitles.length > 0 || preferredSectors.length > 0) {
+        candidates.sort((a, b) => {
+          const aTitle = a.meta?.find((m) => m.key === "title")?.value ?? "";
+          const bTitle = b.meta?.find((m) => m.key === "title")?.value ?? "";
+          const aTags = a.tags.map((t) => t.toLowerCase());
+          const bTags = b.tags.map((t) => t.toLowerCase());
+
+          const aPreferred =
+            (preferredTitles.length > 0 && titleMatches(aTitle, preferredTitles)) ||
+            (preferredSectors.length > 0 &&
+              preferredSectors.some((s) => aTags.includes(s.toLowerCase())));
+          const bPreferred =
+            (preferredTitles.length > 0 && titleMatches(bTitle, preferredTitles)) ||
+            (preferredSectors.length > 0 &&
+              preferredSectors.some((s) => bTags.includes(s.toLowerCase())));
+
+          if (aPreferred && !bPreferred) return -1;
+          if (!aPreferred && bPreferred) return 1;
+          return 0;
+        });
+      }
+    }
 
     // How many slots to fill
     const currentKept = stillQualify.length;

--- a/src/components/OutreachTaskCard.tsx
+++ b/src/components/OutreachTaskCard.tsx
@@ -85,6 +85,13 @@ export default function OutreachTaskCard({ task, message, claudeEnabled = false 
   // Log Response drawer
   const [drawerOpen, setDrawerOpen] = useState(false);
 
+  // Feedback state
+  const [feedbackThumb, setFeedbackThumb] = useState<"up" | "down" | null>(null);
+  const [feedbackText, setFeedbackText] = useState("");
+  const [feedbackSubmitted, setFeedbackSubmitted] = useState(false);
+  const [feedbackSubmitting, setFeedbackSubmitting] = useState(false);
+  const [showFeedbackInput, setShowFeedbackInput] = useState(false);
+
   const touchNumber = nextTouchNumber(stage);
 
   const handleCopy = useCallback(async () => {
@@ -157,6 +164,35 @@ export default function OutreachTaskCard({ task, message, claudeEnabled = false 
     setTouchError(null);
     console.log("Response logged:", responseType);
   }, []);
+
+  const handleFeedbackThumb = useCallback((thumb: "up" | "down") => {
+    setFeedbackThumb(thumb);
+    setShowFeedbackInput(true);
+    setFeedbackSubmitted(false);
+  }, []);
+
+  const handleFeedbackSubmit = useCallback(async (thumbOverride?: "up" | "down") => {
+    const thumb = thumbOverride ?? feedbackThumb;
+    if (!thumb) return;
+    setFeedbackSubmitting(true);
+    try {
+      await fetch("/api/outreach/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          entityId: contact.id,
+          thumb,
+          text: feedbackText || undefined,
+        }),
+      });
+      setFeedbackSubmitted(true);
+      setShowFeedbackInput(false);
+    } catch {
+      // Silent fail — feedback is non-critical
+    } finally {
+      setFeedbackSubmitting(false);
+    }
+  }, [feedbackThumb, feedbackText, contact.id]);
 
   const fitColors: Record<string, string> = {
     high: "bg-green-100 text-green-700",
@@ -368,6 +404,64 @@ export default function OutreachTaskCard({ task, message, claudeEnabled = false 
             </button>
           </div>
         </div>
+
+        {/* Feedback row */}
+        {!feedbackSubmitted ? (
+          <div className="px-4 md:px-5 pb-3 pt-1">
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-bisque-400">This prospect:</span>
+              <button
+                onClick={() => handleFeedbackThumb("up")}
+                className={`text-base leading-none rounded px-1.5 py-0.5 transition-colors focus:outline-none ${
+                  feedbackThumb === "up"
+                    ? "bg-green-100 text-green-600"
+                    : "text-bisque-400 hover:text-green-500 hover:bg-green-50"
+                }`}
+                aria-label="Thumbs up — good prospect"
+                title="Good prospect"
+              >
+                👍
+              </button>
+              <button
+                onClick={() => handleFeedbackThumb("down")}
+                className={`text-base leading-none rounded px-1.5 py-0.5 transition-colors focus:outline-none ${
+                  feedbackThumb === "down"
+                    ? "bg-red-50 text-red-500"
+                    : "text-bisque-400 hover:text-red-400 hover:bg-red-50"
+                }`}
+                aria-label="Thumbs down — bad prospect"
+                title="Not a good prospect"
+              >
+                👎
+              </button>
+            </div>
+            {showFeedbackInput && feedbackThumb && (
+              <div className="mt-2 flex items-center gap-2">
+                <input
+                  type="text"
+                  value={feedbackText}
+                  onChange={(e) => setFeedbackText(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") handleFeedbackSubmit();
+                  }}
+                  placeholder="Optional: tell us why..."
+                  className="flex-1 text-xs border border-bisque-200 rounded px-2 py-1.5 text-bisque-700 placeholder:text-bisque-300 focus:outline-none focus:ring-1 focus:ring-bisque-300"
+                />
+                <button
+                  onClick={() => handleFeedbackSubmit()}
+                  disabled={feedbackSubmitting}
+                  className="px-2 py-1.5 text-xs font-medium rounded bg-bisque-100 text-bisque-700 hover:bg-bisque-200 transition-colors focus:outline-none disabled:opacity-50 whitespace-nowrap"
+                >
+                  {feedbackSubmitting ? "…" : "Submit"}
+                </button>
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="px-4 md:px-5 pb-3 pt-1">
+            <span className="text-xs text-bisque-400">Thanks for the feedback!</span>
+          </div>
+        )}
 
         {/* Expandable message panel */}
         {expanded && (


### PR DESCRIPTION
## Summary

- **API**: `POST /api/outreach/feedback` — stores `feedback_thumb`, `feedback_text`, `feedback_date` as Kissinger meta fields on person entities
- **UI**: 👍/👎 row below each outreach card with optional text input; shows "Thanks!" after submission
- **reload-tasks**: reads `~/lobster-workspace/data/prospect-criteria.json` (if present) to filter excluded titles/sectors and prioritize preferred ones
- **Scheduled job**: `prospect-refinement` runs daily at 3am — queries Kissinger for 30 days of feedback, calls Claude Sonnet to synthesize criteria JSON, saves to `prospect-criteria.json`

## Test plan

- [ ] Click 👍 or 👎 on an outreach card — feedback input appears
- [ ] Submit with optional text — "Thanks!" confirmation appears
- [ ] Check Kissinger entity meta for `feedback_thumb`, `feedback_text`, `feedback_date`
- [ ] `POST /api/outreach/reload-tasks` — confirm it loads criteria and filters correctly
- [ ] Verify `lobster-prospect-refinement.timer` is active via `systemctl status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)