### PR TITLE
Add Skip button to OutreachTaskCard

### DIFF
--- a/src/app/api/outreach/reload-tasks/route.ts
+++ b/src/app/api/outreach/reload-tasks/route.ts
@@ -166,9 +166,10 @@ export async function POST(request: Request) {
       (p) => !(p.tags.includes("linkedin") && isUSContact(p))
     );
 
-    // Determine eligible candidates to add (linkedin + US, not already prospect-contact)
+    // Determine eligible candidates to add (linkedin + US, not already prospect-contact,
+    // and not previously skipped via the "prospect-skipped" tag)
     let candidates = nonOutreach.filter(
-      (p) => p.tags.includes("linkedin") && isUSContact(p)
+      (p) => p.tags.includes("linkedin") && isUSContact(p) && !p.tags.includes("prospect-skipped")
     );
 
     // Apply prospect criteria filtering/prioritization if available

--- a/src/app/api/outreach/skip/route.ts
+++ b/src/app/api/outreach/skip/route.ts
@@ -1,0 +1,136 @@
+/**
+ * POST /api/outreach/skip
+ *
+ * Skips a prospect contact by:
+ *   1. Removing "prospect-contact" tag (removes them from the outreach list)
+ *   2. Adding "prospect-skipped" tag (prevents reload-tasks from re-adding them)
+ *
+ * Request body (JSON):
+ * { entityId: string }
+ *
+ * Response:
+ * { ok: true }
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { revalidateTag } from "next/cache";
+
+const KISSINGER_API_URL =
+  process.env.KISSINGER_API_URL ?? "http://localhost:8080/graphql";
+const KISSINGER_API_TOKEN = process.env.KISSINGER_API_TOKEN ?? "";
+
+const COOKIE_NAME = "eloso_session";
+const SESSION_VALUE = "authenticated";
+
+/** Minimal GraphQL helper (no Next.js caching — mutations bypass cache). */
+async function gqlMutate<T = unknown>(
+  query: string,
+  variables: Record<string, unknown>
+): Promise<T> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (KISSINGER_API_TOKEN) {
+    headers["Authorization"] = `Bearer ${KISSINGER_API_TOKEN}`;
+  }
+
+  const res = await fetch(KISSINGER_API_URL, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ query, variables }),
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    throw new Error(`Kissinger request failed: ${res.status} ${res.statusText}`);
+  }
+
+  const json = (await res.json()) as { data?: T; errors?: unknown[] };
+  if (json.errors && json.errors.length > 0) {
+    throw new Error(`Kissinger errors: ${JSON.stringify(json.errors)}`);
+  }
+  return json.data as T;
+}
+
+const ENTITY_TAGS_QUERY = `
+  query EntityTags($id: String!) {
+    entity(id: $id) {
+      tags
+    }
+  }
+`;
+
+const UPDATE_ENTITY_TAGS_MUTATION = `
+  mutation UpdateEntityTags($id: String!, $input: UpdateEntityInput!) {
+    updateEntity(id: $id, input: $input) {
+      id
+      tags
+    }
+  }
+`;
+
+export async function POST(request: NextRequest) {
+  // Auth: valid session cookie OR internal secret
+  const internalSecret = process.env.LOBSTER_INTERNAL_SECRET;
+  const providedSecret = request.headers.get("X-Internal-Secret");
+  const isInternalCall =
+    internalSecret && providedSecret && providedSecret === internalSecret;
+
+  const cookieHeader = request.headers.get("cookie") ?? "";
+  const hasSessionCookie = cookieHeader
+    .split(";")
+    .map((c) => c.trim())
+    .some((c) => c === `${COOKIE_NAME}=${SESSION_VALUE}`);
+
+  if (!isInternalCall && !hasSessionCookie) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { entityId } = body as { entityId?: string };
+
+  if (!entityId || typeof entityId !== "string") {
+    return NextResponse.json(
+      { error: "entityId is required" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    // Fetch current tags
+    const entityData = await gqlMutate<{
+      entity: { tags: string[] };
+    }>(ENTITY_TAGS_QUERY, { id: entityId });
+
+    const currentTags = entityData.entity?.tags ?? [];
+
+    // Remove prospect-contact, add prospect-skipped (if not already present)
+    const newTags = [
+      ...currentTags.filter((t) => t !== "prospect-contact"),
+      ...(currentTags.includes("prospect-skipped") ? [] : ["prospect-skipped"]),
+    ];
+
+    await gqlMutate(UPDATE_ENTITY_TAGS_MUTATION, {
+      id: entityId,
+      input: { tags: newTags },
+    });
+
+    // Bust the contacts cache so the outreach page reloads fresh data
+    revalidateTag("contacts");
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error("[outreach/skip] Failed to skip prospect:", msg);
+    return NextResponse.json(
+      { error: "Failed to skip prospect" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/OutreachTaskCard.tsx
+++ b/src/components/OutreachTaskCard.tsx
@@ -82,6 +82,10 @@ export default function OutreachTaskCard({ task, message, claudeEnabled = false 
   const [markingTouch, setMarkingTouch] = useState(false);
   const [touchError, setTouchError] = useState<string | null>(null);
 
+  // Skip state
+  const [skipped, setSkipped] = useState(false);
+  const [skipping, setSkipping] = useState(false);
+
   // Log Response drawer
   const [drawerOpen, setDrawerOpen] = useState(false);
 
@@ -157,6 +161,26 @@ export default function OutreachTaskCard({ task, message, claudeEnabled = false 
     }
   }, [contact.id, touchNumber]);
 
+  const handleSkip = useCallback(async () => {
+    setSkipping(true);
+    try {
+      const res = await fetch("/api/outreach/skip", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ entityId: contact.id }),
+      });
+      if (!res.ok) {
+        const data = (await res.json()) as { error?: string };
+        throw new Error(data.error ?? `HTTP ${res.status}`);
+      }
+      setSkipped(true);
+    } catch (err) {
+      setTouchError(err instanceof Error ? err.message : "Failed to skip");
+    } finally {
+      setSkipping(false);
+    }
+  }, [contact.id]);
+
   const handleResponseSuccess = useCallback((responseType: string) => {
     setDrawerOpen(false);
     setStage("responded");
@@ -217,7 +241,7 @@ export default function OutreachTaskCard({ task, message, claudeEnabled = false 
         />
       )}
 
-      <div className="bg-white rounded-xl border border-bisque-100 shadow-sm overflow-hidden">
+      <div className={`rounded-xl border shadow-sm overflow-hidden transition-all ${skipped ? "bg-gray-50 border-gray-200 opacity-60" : "bg-white border-bisque-100"}`}>
         {/* Card header */}
         <div className="px-4 md:px-5 py-4">
           <div className="flex items-start justify-between gap-3">
@@ -310,6 +334,20 @@ export default function OutreachTaskCard({ task, message, claudeEnabled = false 
                   Responded ✓
                 </span>
               )}
+              {/* Skip button / Skipped badge */}
+              {skipped ? (
+                <span className="px-3 py-1.5 text-sm font-medium rounded-lg bg-gray-100 border border-gray-200 text-gray-500">
+                  Skipped ✓
+                </span>
+              ) : (
+                <button
+                  onClick={handleSkip}
+                  disabled={skipping}
+                  className="px-3 py-1.5 text-sm font-medium rounded-lg border border-gray-200 text-gray-400 hover:bg-gray-50 hover:text-gray-600 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {skipping ? "Skipping…" : "Skip"}
+                </button>
+              )}
             </div>
           </div>
 
@@ -388,6 +426,21 @@ export default function OutreachTaskCard({ task, message, claudeEnabled = false 
               <span className="flex items-center justify-center px-3 py-2.5 min-h-[44px] text-sm font-medium rounded-lg bg-green-100 border border-green-200 text-green-700 whitespace-nowrap">
                 Responded ✓
               </span>
+            )}
+            {/* Mobile: Skip / Skipped */}
+            {skipped ? (
+              <span className="flex items-center justify-center px-3 py-2.5 min-h-[44px] text-sm font-medium rounded-lg bg-gray-100 border border-gray-200 text-gray-500 whitespace-nowrap">
+                Skipped ✓
+              </span>
+            ) : (
+              <button
+                onClick={handleSkip}
+                disabled={skipping}
+                className="flex items-center justify-center px-3 py-2.5 min-h-[44px] text-sm font-medium rounded-lg border border-gray-200 text-gray-400 transition-colors focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
+                aria-label="Skip this prospect"
+              >
+                {skipping ? "…" : "Skip"}
+              </button>
             )}
             <button
               onClick={() => setExpanded((v) => !v)}


### PR DESCRIPTION
## Summary
- Adds a **Skip** button to each outreach card (desktop + mobile) that immediately removes the prospect from the queue and flags them with `prospect-skipped` so they don't get re-added on the next reload
- New `POST /api/outreach/skip` route: fetches current tags, removes `prospect-contact`, adds `prospect-skipped`, busts the contacts cache
- `reload-tasks` now excludes `prospect-skipped` entities from candidate selection
- Card greys out with a "Skipped ✓" badge after clicking (local React state, no page reload needed)

## Test plan
- [ ] Click Skip on an outreach card — card should grey out with "Skipped ✓"
- [ ] Verify in Kissinger the entity has `prospect-skipped` tag and no `prospect-contact` tag
- [ ] Run reload-tasks — confirm the skipped person does not return to the list
- [ ] Verify TypeScript build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)